### PR TITLE
Add history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: ruby
 rvm:
   - 2.2.5
 before_install: gem install bundler -v 1.12.5
+env:
+  - SLUG_LOCALE_COLUMN=true
+  - SLUG_LOCALE_COLUMN=false

--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ necessary overrides if history has been enabled (so the reverse order will not
 work).
 
 To use the history feature, you must add a `locale` column to your
-`friendly_id_slugs` table.
+`friendly_id_slugs` table, which you can do with the `friendly_id_mobility` generator:
+
+```
+rails generate friendly_id_mobility
+```
+
+Then run the generated migration with `rake db:migrate`.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ Article.friendly.find("mon-titre-foo")
 #=> #<Article id: 1 ...>
 ```
 
+### Slug History
+
+To use the FriendlyId history module, use `use: [:history, :mobility]` when
+calling `friendly_id` from your model:
+
+```ruby
+class Article < ActiveRecord::Base
+  include Mobility
+  translates :slug, :title, dirty: true
+
+  extend FriendlyId
+  friendly_id :title, use: [:history, :mobility]
+end
+```
+
+It is important to have `:history` *before* `:mobility` here, since the
+Mobility module looks for the presence of the history module and only adds
+necessary overrides if history has been enabled (so the reverse order will not
+work).
+
+To use the history feature, you must add a `locale` column to your
+`friendly_id_slugs` table.
+
 Contributing
 ------------
 

--- a/friendly_id-mobility.gemspec
+++ b/friendly_id-mobility.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "database_cleaner", '~> 1.5.3'
+  spec.add_development_dependency "generator_spec", '~> 0.9.3'
 end

--- a/lib/friendly_id/mobility.rb
+++ b/lib/friendly_id/mobility.rb
@@ -65,14 +65,6 @@ module FriendlyId
         where(friendly_id_config.query_field => id).exists? ||
           joins(:slugs).where(slug_history_clause(id)).exists?
       end
-
-      private
-
-      def slug_history_clause(id)
-        Slug.arel_table[:sluggable_type].eq(base_class.to_s).
-          and(Slug.arel_table[:slug].eq(id)).
-          and(Slug.arel_table[:locale].eq(::Mobility.locale))
-      end
     end
   end
 end

--- a/lib/friendly_id/slug_decorator.rb
+++ b/lib/friendly_id/slug_decorator.rb
@@ -1,6 +1,11 @@
 require "friendly_id"
 
+# This override must handle both the situation where locale column has been
+# added to the slugs table, and also the situation where it has not.
+#
 FriendlyId::Slug.class_eval do
+  default_scope { column_names.include?("locale") ? where(locale: ::Mobility.locale) : all }
+
   before_save do
     self.locale ||= ::Mobility.locale if respond_to?(:locale=)
   end

--- a/lib/friendly_id/slug_decorator.rb
+++ b/lib/friendly_id/slug_decorator.rb
@@ -2,6 +2,6 @@ require "friendly_id"
 
 FriendlyId::Slug.class_eval do
   before_save do
-    self.locale = ::Mobility.locale if self.respond_to?(:locale=)
+    self.locale ||= ::Mobility.locale if respond_to?(:locale=)
   end
 end

--- a/lib/friendly_id/slug_decorator.rb
+++ b/lib/friendly_id/slug_decorator.rb
@@ -1,0 +1,7 @@
+require "friendly_id"
+
+FriendlyId::Slug.class_eval do
+  before_save do
+    self.locale = ::Mobility.locale if self.respond_to?(:locale=)
+  end
+end

--- a/lib/generators/friendly_id_mobility_generator.rb
+++ b/lib/generators/friendly_id_mobility_generator.rb
@@ -1,0 +1,24 @@
+require 'rails/generators'
+require "rails/generators/active_record"
+
+class FriendlyIdMobilityGenerator < ::Rails::Generators::Base
+  include ::Rails::Generators::Migration
+
+  desc "Generates migration to add locale column to friendly_id_slugs table."
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  def self.next_migration_number(dirname)
+    ::ActiveRecord::Generators::Base.next_migration_number(dirname)
+  end
+
+  def create_migration_file
+    template = "add_locale_to_friendly_id_slugs"
+    migration_dir = File.expand_path("db/migrate")
+    if self.class.migration_exists?(migration_dir, template)
+      ::Kernel.warn "Migration already exists."
+    else
+      migration_template "migration.rb", "db/migrate/#{template}.rb"
+    end
+  end
+end

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,0 +1,11 @@
+class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+  def change
+    add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope
+
+    remove_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }
+    remove_index :friendly_id_slugs, [:slug, :sluggable_type, :scope]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope, :locale], length: { slug: 70, sluggable_type: 50, scope: 70, locale: 2 }, unique: true, name: :index_friendly_id_slugs_unique
+    add_index :friendly_id_slugs, :locale
+  end
+end

--- a/spec/friendly_id/mobility_spec.rb
+++ b/spec/friendly_id/mobility_spec.rb
@@ -184,7 +184,7 @@ describe FriendlyId::Mobility do
             post.title = "Foo Titre"
             post.save!
           end
-        }.to change(FriendlyId::Slug, :count).by(1)
+        }.to change(FriendlyId::Slug.unscoped, :count).by(1)
 
         slug = post.slugs.find { |slug| slug.locale == "fr" }
         expect(slug.slug).to eq("foo-titre")

--- a/spec/friendly_id/mobility_spec.rb
+++ b/spec/friendly_id/mobility_spec.rb
@@ -124,6 +124,8 @@ describe FriendlyId::Mobility do
   end
 
   describe "history" do
+    # Check that normal history functions are working, both with and without locale
+    # column on the slugs table.
     describe "base features" do
       it "inserts record in slugs table on create" do
         post = Post.create!(title: "foo title", content: "once upon a time...")
@@ -166,7 +168,7 @@ describe FriendlyId::Mobility do
       end
     end
 
-    describe "translations" do
+    describe "translations", :locale_slugs do
       it "stores locale on slugs" do
         expect {
           Post.create(title: "Foo Title")

--- a/spec/generators/friendly_id_mobility_generator_spec.rb
+++ b/spec/generators/friendly_id_mobility_generator_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+require "generators/friendly_id_mobility_generator"
+
+describe FriendlyIdMobilityGenerator, type: :generator do
+  require "generator_spec/test_case"
+  include GeneratorSpec::TestCase
+
+  destination File.expand_path("../tmp", __FILE__)
+
+  before(:all) do
+    prepare_destination
+    run_generator
+  end
+  after(:all) { prepare_destination }
+
+  it "generates migration to add locale to friendly_id_slugs table" do
+    expect(destination_root).to have_structure {
+      directory "db" do
+        directory "migrate" do
+          migration "add_locale_to_friendly_id_slugs" do
+            contains "class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[5.0]"
+            contains "def change"
+            contains "add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope"
+            contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type]"
+            contains "add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }"
+            contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type, :scope]"
+            contains "add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope, :locale], length: { slug: 70, sluggable_type: 50, scope: 70, locale: 2 }, unique: true, name: :index_friendly_id_slugs_unique"
+            contains "add_index :friendly_id_slugs, :locale"
+          end
+        end
+      end
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration
     create_table :articles do |t|
     end
 
+    create_table :posts do |t|
+      t.boolean :published
+    end
+
     create_table :mobility_string_translations do |t|
       t.string  :locale
       t.string  :key
@@ -38,6 +42,15 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration
       t.integer :translatable_id
       t.string  :translatable_type
       t.timestamps
+    end
+
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,                      null: false
+      t.integer  :sluggable_id,              null: false
+      t.string   :sluggable_type, limit: 50
+      t.string   :locale,                    null: false
+      t.string   :scope
+      t.datetime :created_at
     end
   end
 end
@@ -56,6 +69,15 @@ class Article < ActiveRecord::Base
 
   extend FriendlyId
   friendly_id :title, use: :mobility
+end
+
+class Post < ActiveRecord::Base
+  include Mobility
+  translates :slug, :title, type: :string, dirty: true, backend: :key_value
+  translates :content, type: :text, dirty: true, backend: :key_value
+
+  extend FriendlyId
+  friendly_id :title, use: [:history, :mobility]
 end
 
 ActiveRecord::Migration.verbose = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration
       t.string   :slug,                      null: false
       t.integer  :sluggable_id,              null: false
       t.string   :sluggable_type, limit: 50
-      t.string   :locale,                    null: false
+      t.string   :locale,                    null: false if ENV['SLUG_LOCALE_COLUMN'] == 'true'
       t.string   :scope
       t.datetime :created_at
     end
@@ -95,4 +95,6 @@ RSpec.configure do |config|
   config.after :each do
     DatabaseCleaner.clean
   end
+
+  config.filter_run_excluding :locale_slugs unless ENV['SLUG_LOCALE_COLUMN'] == 'true'
 end


### PR DESCRIPTION
Resolves #1.

There is no generator to add the `locale` column to the `slugs` table yet (and
associated indices), but I'll add it later. This should work as long as the
column is present.