### PR TITLE
Release 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'friendly_id-mobility', '~> 1.0.1'
+gem 'friendly_id-mobility', '~> 1.0.2'
 ```
 
 And then execute:

--- a/friendly_id-mobility.gemspec
+++ b/friendly_id-mobility.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files        = Dir['{lib/**/*,[A-Z]*}']
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mobility',    '>= 1.0.0', '< 2.0'
+  spec.add_dependency 'mobility',    '>= 1.0.1', '< 2.0'
   spec.add_dependency 'friendly_id', '>= 5.0.0', '< 5.5'
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/friendly_id/mobility.rb
+++ b/lib/friendly_id/mobility.rb
@@ -23,8 +23,7 @@ module FriendlyId
 
         mod = Module.new do
           def friendly
-            # TODO: Make this constant public in Mobility 1.1 so we don't need const_get
-            super.extending(::Mobility::Plugins::ActiveRecord::Query.const_get(:QueryExtension))
+            super.extending(::Mobility::Plugins::ActiveRecord::Query::QueryExtension)
           end
         end
         model_class.send :extend, mod

--- a/lib/friendly_id/mobility/version.rb
+++ b/lib/friendly_id/mobility/version.rb
@@ -1,5 +1,5 @@
 module FriendlyId
   module Mobility
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
Depends on Mobility 1.0.1, which makes QueryExtension public so we don't need const_get.