### PR TITLE
Slug changes detection problem

### DIFF
--- a/lib/friendly_id/mobility.rb
+++ b/lib/friendly_id/mobility.rb
@@ -52,7 +52,7 @@ module FriendlyId
     def set_slug(normalized_slug = nil)
       super
       changed.each do |change|
-        if change =~ /\A(?:#{friendly_id_config.base}|#{friendly_id_config.slug_column})_([a-z]{2}(_[a-z]{2})?)/
+        if change =~ /\A(?:#{friendly_id_config.base}|#{friendly_id_config.slug_column})_([a-z]{2}(_[a-z]{2})?)\Z/
           locale, suffix = $1.split('_'.freeze)
           locale = "#{locale}-#{suffix.upcase}".freeze if suffix
           ::Mobility.with_locale(locale) { super }

--- a/spec/friendly_id/mobility_spec.rb
+++ b/spec/friendly_id/mobility_spec.rb
@@ -168,6 +168,18 @@ describe FriendlyId::Mobility do
         expect(article.slug_en).to eq("english-title")
         expect(article.slug_es).to eq("titulo-espanol")
       end
+
+      # Regression: https://github.com/shioyama/friendly_id-mobility/pull/26
+      it "ignores changes to other columns" do
+        I18n.enforce_available_locales = true
+        application = double(:application)
+        allow(application).to receive_message_chain(:config, :i18n, :available_locales).and_return([:en, :ja])
+        expect(Rails).to receive(:application).at_least(1).time.and_return(application)
+        article = Article.new(title_en: "English title", title_translations: "foo")
+        expect { article.save }.not_to raise_error
+      ensure
+        I18n.enforce_available_locales = false
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration[ENV['RAILS_VERSION'].to_f
     end
 
     create_table :articles do |t|
+      t.string :title_translations
     end
 
     create_table :posts do |t|


### PR DESCRIPTION
With Jsonb backend (hashedValue same) and column_suffix option (ex: _translations), the regexp in set_slug method isn't precise enough and catch the json column (ex: title_translations) and raise an error (Mobility::InvalidLocale: :tr is not a valid locale)

We add an \Z at the end of the regexp to fix it

Thank you for releasing Mobility 1.0 and those plugins!

Cheers,
Kevyn