### PR TITLE
allow translated and non-translated slugs with history in the same project

### DIFF
--- a/lib/friendly_id/slug_decorator.rb
+++ b/lib/friendly_id/slug_decorator.rb
@@ -4,9 +4,9 @@ require "friendly_id"
 # added to the slugs table, and also the situation where it has not.
 #
 FriendlyId::Slug.class_eval do
-  default_scope { column_names.include?("locale") ? where(locale: ::Mobility.locale) : all }
+  default_scope { column_names.include?("locale") ? where(locale: [::Mobility.locale, nil]) : all }
 
   before_save do
-    self.locale ||= ::Mobility.locale if respond_to?(:locale=)
+    self.locale ||= ::Mobility.locale if respond_to?(:locale=) && self.sluggable.class.friendly_id_config.uses?(:mobility)
   end
 end

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,6 +1,6 @@
 class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope
+    add_column :friendly_id_slugs, :locale, :string, null: :true, after: :scope
 
     remove_index :friendly_id_slugs, [:slug, :sluggable_type]
     add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }

--- a/spec/generators/friendly_id_mobility_generator_spec.rb
+++ b/spec/generators/friendly_id_mobility_generator_spec.rb
@@ -20,7 +20,7 @@ describe FriendlyIdMobilityGenerator, type: :generator do
           migration "add_locale_to_friendly_id_slugs" do
             contains "class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
             contains "def change"
-            contains "add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope"
+            contains "add_column :friendly_id_slugs, :locale, :string, null: :true, after: :scope"
             contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type]"
             contains "add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }"
             contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type, :scope]"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,12 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration[ENV['RAILS_VERSION'].to_f
     create_table :publishers do |t|
     end
 
+    create_table :products do |t|
+      t.string :name
+      t.string :slug
+      t.string :description
+    end
+
     create_table :mobility_string_translations do |t|
       t.string  :locale
       t.string  :key
@@ -62,7 +68,7 @@ class FriendlyIdMobilityTest < ActiveRecord::Migration[ENV['RAILS_VERSION'].to_f
       t.string   :slug,                      null: false
       t.integer  :sluggable_id,              null: false
       t.string   :sluggable_type, limit: 50
-      t.string   :locale,                    null: false if ENV['SLUG_LOCALE_COLUMN'] == 'true'
+      t.string   :locale                                if ENV['SLUG_LOCALE_COLUMN'] == 'true'
       t.string   :scope
       t.datetime :created_at
     end
@@ -126,6 +132,14 @@ class Publisher < ActiveRecord::Base
   translates :name, type: :string
 
   has_many :novels
+end
+
+class Product < ActiveRecord::Base
+  extend Mobility
+  translates :description, type: :string
+
+  extend FriendlyId
+  friendly_id :name, use: [:slugged, :history]
 end
 
 ActiveRecord::Migration.verbose = false


### PR DESCRIPTION
Solves #27 by loosen the `locale` constraint and taking the :mobility plugin usage into account for each `sluggable`.