### PR TITLE
Make sure to always take slug_column as string

### DIFF
--- a/lib/friendly_id/mobility.rb
+++ b/lib/friendly_id/mobility.rb
@@ -30,7 +30,7 @@ module FriendlyId
       end
 
       def advise_against_untranslated_model(model)
-        field = model.friendly_id_config.query_field
+        field = model.friendly_id_config.query_field.to_s
         if model.included_modules.grep(::Mobility::Translations).empty? || model.mobility_attributes.exclude?(field)
           raise "[FriendlyId] You need to translate the '#{field}' field with " \
             "Mobility (add 'translates :#{field}' in your model '#{model.name}')"


### PR DESCRIPTION
## Description
Using friendly_id-mobility I came to this error:

     [FriendlyId] You need to translate the 'fieldA' field with Mobility (add 'translates :fieldA' in your model 
     'modelA')
     
But translation for 'fieldA' was already added to the 'modelA' and the code looks like this:
`translates :fieldA`
`friendly_id :fieldA, slug_column: :fieldA, use: [:history, :mobility]`

It turns out that in the method `advise_against_untranslated_model(model)` in file `friendly_id_mobility.rb`

`field = model.friendly_id_config.query_field` - this returns symbol `:fieldA`

`model.mobility_attributes` - this returns array of strings: `["fieldA"]`

So this evaluation: `model.mobility_attributes.exclude?(field)` is true and the error is raised.

## Solution
My fix for that is very simple. I just make sure that `field` will always be a string so `model.mobility_attributes.exclude?(field)` can work as expected.


