### PR TITLE
chore: update build matrix to be inline with mobility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.7'
-          - '2.6'
+          - '3.3'
+          - '3.2'
+          - '3.1'
         rails:
-          - '5.2'
-          - '6.0'
-          - '6.1'
           - '7.0'
+          - '7.1'
+          - '7.2'
+          - '8.0'
     env:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0
 
+### 1.0.5
+* Update CI matrix to be inline with mobility
+
 ### 1.0.4
 * Convert field from symbol to string value when comparing with
   `mobility_attributes`

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rake'
-
-  if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'] < '5.2'
-    gem 'sqlite3', '~> 1.3.13'
-  else
-    gem 'sqlite3'
-  end
+  gem 'sqlite3'
 
   gem 'rails', "~> #{ENV['RAILS_VERSION'] || '7.0'}.0"
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'friendly_id-mobility', '~> 1.0.4'
+gem 'friendly_id-mobility', '~> 1.0.5'
 ```
 
 And then execute:

--- a/lib/friendly_id/mobility/version.rb
+++ b/lib/friendly_id/mobility/version.rb
@@ -1,5 +1,5 @@
 module FriendlyId
   module Mobility
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,6 +1,6 @@
 class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope
+    add_column :friendly_id_slugs, :locale, :string, null: :false
 
     remove_index :friendly_id_slugs, [:slug, :sluggable_type]
     add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }

--- a/spec/generators/friendly_id_mobility_generator_spec.rb
+++ b/spec/generators/friendly_id_mobility_generator_spec.rb
@@ -20,7 +20,7 @@ describe FriendlyIdMobilityGenerator, type: :generator do
           migration "add_locale_to_friendly_id_slugs" do
             contains "class AddLocaleToFriendlyIdSlugs < ActiveRecord::Migration[#{ENV['RAILS_VERSION']}]"
             contains "def change"
-            contains "add_column :friendly_id_slugs, :locale, :string, null: :false, after: :scope"
+            contains "add_column :friendly_id_slugs, :locale, :string, null: :false"
             contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type]"
             contains "add_index :friendly_id_slugs, [:slug, :sluggable_type, :locale], length: { slug: 140, sluggable_type: 50, locale: 2 }"
             contains "remove_index :friendly_id_slugs, [:slug, :sluggable_type, :scope]"


### PR DESCRIPTION
+ added the fix from #36 

would love to see a release as we run on mobility 5.5 and have to rely on unreleased code.